### PR TITLE
Optionally ignore if we find a newer AMI for an existing EC2 instance

### DIFF
--- a/password-manager/main.tf
+++ b/password-manager/main.tf
@@ -71,6 +71,10 @@ resource "aws_instance" "vaultwarden_server" {
   tags      = {
     Name = "Vaultwarden Server"
   }
+
+  lifecycle {
+    ignore_changes = var.ignore_ami_change ? [] : [ami]
+  }
 }
 
 #Create load balancer

--- a/password-manager/variables.tf
+++ b/password-manager/variables.tf
@@ -30,3 +30,8 @@ variable "server_subnets" {
 variable "company_domain" {
   type = string
 }
+
+variable "ignore_ami_change" {
+  type    = bool
+  default = false
+}

--- a/vpn/main.tf
+++ b/vpn/main.tf
@@ -60,6 +60,10 @@ resource "aws_instance" "vpn_server" {
   tags      = {
     Name = "TeamfrontVPN"
   }
+
+  lifecycle {
+    ignore_changes = var.ignore_ami_change ? [] : [ami]
+  }
 }
 
 # Add A record for vpn.comanydomain.com

--- a/vpn/variables.tf
+++ b/vpn/variables.tf
@@ -16,3 +16,8 @@ variable "company_domain" {
   type        = string
   description = "Company domain e.g. companyA.com"
 }
+
+variable "ignore_ami_change" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
# Summary of source changes
New variable to optionally ignore any change to the AMI ID on the EC2 so it doesn't completely replace the EC2

# Motivation and Context
When you create the EC2 it reads the data for AMI ID. After a while, the data gets a new AMI ID. Terraform then wants to completely replace the EC2.

# Test Instructions
1. Apply and create an EC2 for the VPN or Vaultwarden modules
2. Wait for a new AMI to be released
3. Plan on existing resources
4. Notice it wants to replace the EC2
5. Add `ignore_ami_change = true` to the module input
6. Plan on existing resources
7. Notice it no longer wants to replace the EC2