### PR TITLE
Enhancement/ignore_ec2_ami_change

### DIFF
--- a/password-manager/main.tf
+++ b/password-manager/main.tf
@@ -63,17 +63,18 @@ resource "aws_instance" "vaultwarden_server" {
   root_block_device {
     volume_size           = 30
     encrypted             = true
-    kms_key_id            = data.aws_kms_key.aws_managed_ebs_key.id
+    kms_key_id            = data.aws_kms_key.aws_managed_ebs_key.arn
     delete_on_termination = false
   }
 
   user_data = file("${path.module}/scripts/setup_vaultwarden.sh")
-  tags      = {
-    Name = "Vaultwarden Server"
-  }
+  tags      = merge({
+    Name = "Vaultwarden Server",
+    snapshot = "True"
+  }, var.tags)
 
   lifecycle {
-    ignore_changes = var.ignore_ami_change ? [] : [ami]
+    ignore_changes = [ami]
   }
 }
 

--- a/password-manager/variables.tf
+++ b/password-manager/variables.tf
@@ -30,8 +30,3 @@ variable "server_subnets" {
 variable "company_domain" {
   type = string
 }
-
-variable "ignore_ami_change" {
-  type    = bool
-  default = false
-}

--- a/vpn/main.tf
+++ b/vpn/main.tf
@@ -57,12 +57,13 @@ resource "aws_instance" "vpn_server" {
   }
 
   user_data = file("${path.module}/scripts/setup_vpn.sh")
-  tags      = {
-    Name = "TeamfrontVPN"
-  }
+  tags      = merge({
+    Name = "TeamfrontVPN",
+    snapshot = "True"
+  }, var.tags)
 
   lifecycle {
-    ignore_changes = var.ignore_ami_change ? [] : [ami]
+    ignore_changes = [ami]
   }
 }
 

--- a/vpn/variables.tf
+++ b/vpn/variables.tf
@@ -16,8 +16,3 @@ variable "company_domain" {
   type        = string
   description = "Company domain e.g. companyA.com"
 }
-
-variable "ignore_ami_change" {
-  type    = bool
-  default = false
-}


### PR DESCRIPTION
# Summary of source changes
- AMI changes always ignored, not optional
- Intake vars.tags to override default EC2 tags, like the other resources
- Password Manager EBS Key input should be ARN, not ID
- Add `snapshot = "True"` tag for Teamfront's DLM requirement

# Motivation and Context
We want to avoid changes to the EC2 that might force a replacement. Teamfront is requiring snapshots of the EC2s. We want the EC2 tags to be overridable by incoming variable.

# Test Instructions
1. Apply and create an EC2 for the VPN or Vaultwarden modules
1. Wait for a new AMI to be released
1. Plan on existing resources
1. Notice it wants to replace the EC2
1. Add ignore_ami_change = true to the module input
1. Plan on existing resources
1. Notice it no longer wants to replace the EC2